### PR TITLE
Added support for all empty elements based on list from MDN

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -166,11 +166,20 @@ parseCss cssText = CSS cssMap
 isEmpty :: Text -> Bool
 isEmpty =
   flip elem
-  [ "img"
-  , "hr"
-  , "meta"
-  , "link"
+  [ "area"
+  , "base"
   , "br"
+  , "col"
+  , "embed"
+  , "hr"
+  , "img"
+  , "input"
+  , "link"
+  , "meta"
+  , "param"
+  , "source"
+  , "track"
+  , "wbr"
   ]
 
 closeTag :: Parser ()
@@ -243,5 +252,3 @@ removeComments = go Normal Nothing
          if [prev,c] == "->"
            then go Normal (Just c) next
            else go InComment (Just c) next
-
-


### PR DESCRIPTION
Certain empty elements (like `input` and `source`) are not currently supported by miso-from-html. This makes using miso-from-html on forms very tedious—closing tags have to be added to every input field in the HTML source and then the empty brackets have to be removed from the generated miso.

I updated the list of empty elements in `Main.hs` based on the MDN glossary of empty elements - https://developer.mozilla.org/en-US/docs/Glossary/empty_element