### PR TITLE
Handle hyphens properly

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -59,14 +59,24 @@ instance Show Attr where
     [ "style_ $ "
     , T.unpack v
     ]
-  show (Attr k (Just v)) =
-    mconcat
-    [ T.unpack k
-    , "_ "
-    , "\""
-    , T.unpack v
-    , "\""
-    ]
+  show (Attr k (Just v))
+    | T.any (=='-') k =
+      mconcat
+      [ "textProp \""
+      , T.unpack k
+      , "\""
+      , " \""
+      , T.unpack v
+      , "\""
+      ]
+    | otherwise =
+      mconcat
+      [ T.unpack k
+      , "_ "
+      , "\""
+      , T.unpack v
+      , "\""
+      ]
   show (Attr "checked" Nothing) =
     "checked_ True"
   show (Attr k Nothing) =


### PR DESCRIPTION
Useul for data-* attributes.

```bash
$ runghc Main.hs <<< '<a data-toggle="foo" id="a"></a>'
```

```haskell
a_ 
    [ textProp "data-toggle" "foo" 
    , id_ "a" 
    ] []
```